### PR TITLE
Formatting changes, -p fix and remove excess errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ You can:
   rpipress-downloader --books
   ```
 
-- download to a specific base path,
+- download to a specific path,
 
   ```bash
-  rpipress-downloader --path /home/ubuntu/Documents
+  rpipress-downloader --path /home/ubuntu/Documents/Raspberrypi
   ```
 
 - combine options,
 
   ```bash
-  rpipress-downloader -a -m magpi -b -p /home/ubuntu/Documents
+  rpipress-downloader -ab -m magpi -p /home/ubuntu/Documents/Raspberrypi
   ```
 
-will download all MagPi issues and books in `/home/ubuntu/Documents/rpipress/MagPi`.
+will download all MagPi issues and books to `/home/ubuntu/Documents/Raspberrypi/MagPi`.
 
 ## Options
 

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -1,5 +1,8 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
+# DOWNLOAD PATH NEEDS WORK TO ALLOW CUSTOM FOLDERS
+
 
 import argparse
 import os
@@ -27,8 +30,8 @@ def progress_bar(block_num, block_size, total_size):
 
 def is_a_clink(tag):
     return tag.name == 'a' and \
-           tag.has_attr('class') and \
-           tag.get('class') == ['c-link']
+        tag.has_attr('class') and \
+        tag.get('class') == ['c-link']
 
 
 def downloadable_entry(tag):
@@ -107,19 +110,20 @@ else:
 # Creating the download folder
 if args.path:
     output_base_path = args.path
-elif os.getenv('SNAP_USER_DATA'):
-    output_base_path = os.getenv('SNAP_USER_DATA')
+elif os.getenv('SNAP_USER_DATA/rpipress'):
+    output_base_path = os.getenv('SNAP_USER_DATA/rpipress')
 else:
-    output_base_path = os.path.expanduser('~')
+    output_base_path = os.path.expanduser('~/rpipress')
 
 if not os.path.exists(output_base_path):
-    raise FileNotFoundError(f"{output_base_path} folder does not exist!")
+    os.makedirs(output_base_path)
+    # raise  FileNotFoundError(f"{output_base_path} folder does not exist!")
 
 download = False
 download_error = False
 for magazine_key, magazine in filtered_magazines.items():
 
-    output_path = os.path.join(output_base_path, 'rpipress', magazine.name)
+    output_path = os.path.join(output_base_path, magazine.name)
 
     if not os.path.exists(output_path): os.makedirs(output_path)
 
@@ -140,7 +144,7 @@ for magazine_key, magazine in filtered_magazines.items():
         raise Exception('Could not find latest ' + magazine.name + ' issue number')
     else:
         if not args.quiet:
-            print( 'Latest {} issue is N°{:02d}\n'.format(magazine.name, int(last_issue)) )
+            print('\nLatest {} issue is N°{:02d}'.format(magazine.name, int(last_issue)) )
 
     # start_issue = magazine.first_issue if args.all else int(last_issue)
     start_issue = int(last_issue)-3 if args.all else int(last_issue)
@@ -167,9 +171,9 @@ for magazine_key, magazine in filtered_magazines.items():
                 if not args.quiet:
                     print(
                         log.ERROR
-                        + ' Couldn\'t download {} N°{:02d}\n'.format(magazine.name, issue)
+                        + ' Couldn\'t download the magazine'
                         + colors.FADE
-                        + 'You may need to wait for the free download'
+                        + '\nYou may need to wait for the free download'
                         + colors.ENDC
                     )
                 download_error = True
@@ -180,8 +184,8 @@ for magazine_key, magazine in filtered_magazines.items():
                         + '{} N°{:02d} downloaded!'.format(magazine.name, issue)
                         + colors.ENDC
                     )
-            finally:
-                if not args.quiet: print('')
+            # finally:
+            #     if not args.quiet: print()  # Breaks formatting
 
     if args.books:
 
@@ -195,7 +199,7 @@ for magazine_key, magazine in filtered_magazines.items():
             tags = soup.find_all(book_entry)
         except:
             if not args.quiet:
-                print(log.ERROR + ' There was an error retrieving the book list')
+                print(log.ERROR + 'There was an error retrieving the book list')
         else:
             for tag in tags:
                 books[tag['data-label']] = tag['href']
@@ -207,22 +211,24 @@ for magazine_key, magazine in filtered_magazines.items():
                 # Download each book if not already there
                 for book_name, book_href in books.items():
                     book_path = os.path.join(output_path, book_name + '.pdf')
+                    
                     if not os.path.exists(book_path):
+                        print('\nLatest {} book is \'{}\''.format(magazine.name, book_name))
                         try:
                             r = requests.get(base_url + book_href + '/pdf/download')
                             data = r.text
                             soup = BeautifulSoup(data, "lxml")
                             tag = soup.find(is_a_clink, string='click here to get your free PDF')
                             url = base_url + tag['href']
-
                             show_progress = progress_bar if not args.quiet else None
                             urlreq.urlretrieve(url, book_path, show_progress)
                             download = True
+
                         except:
                             if not args.quiet:
                                 print(
                                     log.ERROR
-                                    + ' Couldn\'t download {} book {}'.format(magazine.name, book_name)
+                                    + ' Couldn\'t download the book'
                                     + colors.FADE
                                     + '.\nYou may need to wait for the free download'
                                     + colors.ENDC
@@ -235,16 +241,16 @@ for magazine_key, magazine in filtered_magazines.items():
                                     +'{} book \'{}\' downloaded!'.format(magazine.name, book_name)
                                     + colors.ENDC
                                 )
-                        finally:
-                            if not args.quiet: print('')
+                        # finally:
+                        #     if not args.quiet: print('')  # Breaks formatting
 
 if not args.quiet:
     if not download and not download_error:
         print(colors.OK + 'You are up to date.' + colors.ENDC)
 
     print(
-        colors.FADE
-        + 'Your favorite magazines are waiting for you in file://'
-        + os.path.join(output_base_path, 'rpipress')
+        colors.OK
+        + '\nYour favorite magazines are waiting for you in file://'
+        + os.path.join(output_base_path)
         + colors.ENDC
     )

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -112,12 +112,9 @@ else:
 
 if not os.path.exists(output_base_path):
     os.makedirs(output_base_path)
-    # raise  FileNotFoundError(f"{output_base_path} folder does not exist!")
 
-download = False
-download_error = False
+
 for magazine_key, magazine in filtered_magazines.items():
-
     output_path = os.path.join(output_base_path, magazine.name)
 
     if not os.path.exists(output_path): os.makedirs(output_path)
@@ -160,7 +157,6 @@ for magazine_key, magazine in filtered_magazines.items():
 
                 show_progress = progress_bar if not args.quiet else None
                 urlreq.urlretrieve(url, issue_path, show_progress)
-                download = True
             except:
                 if not args.quiet:
                     print(
@@ -168,7 +164,7 @@ for magazine_key, magazine in filtered_magazines.items():
                         + 'You may need to wait for the free download.\n'
                         + colors.ENDC
                     )
-                download_error = True
+            
             else:
                 if not args.quiet:
                     print(
@@ -176,10 +172,16 @@ for magazine_key, magazine in filtered_magazines.items():
                         + '{} N°{:02d} downloaded!'.format(magazine.name, issue)
                         + colors.ENDC
                     )
-        
+        # If the magazine already exists
+        else:
+            if not args.quiet:
+                print(
+                    colors.OK 
+                    + 'You are up to date.\n' 
+                    + colors.ENDC
+                )
         
     if args.books:
-
         books = {}
 
         # Find all books
@@ -234,12 +236,6 @@ for magazine_key, magazine in filtered_magazines.items():
 
 
 if not args.quiet:
-    if not download and not download_error:
-        print(
-            colors.OK 
-            + 'You are up to date.\n' 
-            + colors.ENDC
-        )
     print(
         colors.OK
         + 'Your favorite magazines are waiting for you in file://'

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# DOWNLOAD PATH NEEDS WORK TO ALLOW CUSTOM FOLDERS
+
+
 import argparse
 import os
 import urllib.request as urlreq
@@ -143,7 +146,6 @@ for magazine_key, magazine in filtered_magazines.items():
         if not args.quiet:
             print('\nLatest {} issue is N°{:02d}'.format(magazine.name, int(last_issue)) )
 
-    # start_issue = magazine.first_issue if args.all else int(last_issue)
     start_issue = int(last_issue)-3 if args.all else int(last_issue)
 
     # Download issues
@@ -210,7 +212,8 @@ for magazine_key, magazine in filtered_magazines.items():
                     book_path = os.path.join(output_path, book_name + '.pdf')
                     
                     if not os.path.exists(book_path):
-                        print('\nLatest {} book is \'{}\''.format(magazine.name, book_name))
+                        if not args.quiet:
+                            print('\nLatest {} book is \'{}\''.format(magazine.name, book_name))
                         try:
                             r = requests.get(base_url + book_href + '/pdf/download')
                             data = r.text
@@ -238,8 +241,6 @@ for magazine_key, magazine in filtered_magazines.items():
                                     +'{} book \'{}\' downloaded!'.format(magazine.name, book_name)
                                     + colors.ENDC
                                 )
-                        # finally:
-                        #     if not args.quiet: print('')  # Breaks formatting
 
 if not args.quiet:
     if not download and not download_error:

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -114,16 +114,15 @@ if not os.path.exists(output_base_path):
     os.makedirs(output_base_path)
     # raise  FileNotFoundError(f"{output_base_path} folder does not exist!")
 
-download = False
-download_error = False
 for magazine_key, magazine in filtered_magazines.items():
-
+    download_magazine = False
+    download_magazine_error = False
+    
     output_path = os.path.join(output_base_path, magazine.name)
 
     if not os.path.exists(output_path): os.makedirs(output_path)
 
     base_url = 'https://' + magazine_key + '.raspberrypi.org'
-
     issues_url = base_url + '/issues'
 
     # Find latest review number
@@ -160,7 +159,7 @@ for magazine_key, magazine in filtered_magazines.items():
 
                 show_progress = progress_bar if not args.quiet else None
                 urlreq.urlretrieve(url, issue_path, show_progress)
-                download = True
+                download_magazine = True
             except:
                 if not args.quiet:
                     print(
@@ -168,7 +167,7 @@ for magazine_key, magazine in filtered_magazines.items():
                         + 'You may need to wait for the free download.'
                         + colors.ENDC
                     )
-                download_error = True
+                download_magazine_error = True
             else:
                 if not args.quiet:
                     print(
@@ -179,7 +178,6 @@ for magazine_key, magazine in filtered_magazines.items():
         
         
     if args.books:
-
         books = {}
 
         # Find all books
@@ -214,7 +212,7 @@ for magazine_key, magazine in filtered_magazines.items():
                             url = base_url + tag['href']
                             show_progress = progress_bar if not args.quiet else None
                             urlreq.urlretrieve(url, book_path, show_progress)
-                            download = True
+                            download_magazine = True
 
                         except:
                             if not args.quiet:
@@ -223,7 +221,7 @@ for magazine_key, magazine in filtered_magazines.items():
                                     + 'You may need to wait for the free download.'
                                     + colors.ENDC
                                 )
-                            download_error = True
+                            download_magazine_error = True
                         else:
                             if not args.quiet:
                                 print(
@@ -232,14 +230,15 @@ for magazine_key, magazine in filtered_magazines.items():
                                     + colors.ENDC
                                 )
 
+    if not args.quiet:
+        if not download_magazine and not download_magazine_error:
+            print(
+                colors.OK 
+                + 'You are up to date.' 
+                + colors.ENDC
+            )
 
 if not args.quiet:
-    if not download and not download_error:
-        print(
-            colors.OK 
-            + 'You are up to date.' 
-            + colors.ENDC
-        )
     print(
         colors.OK
         + 'Your favorite magazines are waiting for you in file://'

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -112,9 +112,12 @@ else:
 
 if not os.path.exists(output_base_path):
     os.makedirs(output_base_path)
+    # raise  FileNotFoundError(f"{output_base_path} folder does not exist!")
 
-
+download = False
+download_error = False
 for magazine_key, magazine in filtered_magazines.items():
+
     output_path = os.path.join(output_base_path, magazine.name)
 
     if not os.path.exists(output_path): os.makedirs(output_path)
@@ -157,6 +160,7 @@ for magazine_key, magazine in filtered_magazines.items():
 
                 show_progress = progress_bar if not args.quiet else None
                 urlreq.urlretrieve(url, issue_path, show_progress)
+                download = True
             except:
                 if not args.quiet:
                     print(
@@ -164,7 +168,7 @@ for magazine_key, magazine in filtered_magazines.items():
                         + 'You may need to wait for the free download.\n'
                         + colors.ENDC
                     )
-            
+                download_error = True
             else:
                 if not args.quiet:
                     print(
@@ -172,16 +176,10 @@ for magazine_key, magazine in filtered_magazines.items():
                         + '{} N°{:02d} downloaded!'.format(magazine.name, issue)
                         + colors.ENDC
                     )
-        # If the magazine already exists
-        else:
-            if not args.quiet:
-                print(
-                    colors.OK 
-                    + 'You are up to date.\n' 
-                    + colors.ENDC
-                )
+        
         
     if args.books:
+
         books = {}
 
         # Find all books
@@ -236,6 +234,12 @@ for magazine_key, magazine in filtered_magazines.items():
 
 
 if not args.quiet:
+    if not download and not download_error:
+        print(
+            colors.OK 
+            + 'You are up to date.\n' 
+            + colors.ENDC
+        )
     print(
         colors.OK
         + 'Your favorite magazines are waiting for you in file://'

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -165,7 +165,7 @@ for magazine_key, magazine in filtered_magazines.items():
                 if not args.quiet:
                     print(
                         colors.FADE
-                        + 'You may need to wait for the free download.\n'
+                        + 'You may need to wait for the free download.'
                         + colors.ENDC
                     )
                 download_error = True
@@ -220,7 +220,7 @@ for magazine_key, magazine in filtered_magazines.items():
                             if not args.quiet:
                                 print(
                                     colors.FADE
-                                    + 'You may need to wait for the free download.\n'
+                                    + 'You may need to wait for the free download.'
                                     + colors.ENDC
                                 )
                             download_error = True
@@ -237,7 +237,7 @@ if not args.quiet:
     if not download and not download_error:
         print(
             colors.OK 
-            + 'You are up to date.\n' 
+            + 'You are up to date.' 
             + colors.ENDC
         )
     print(

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# DOWNLOAD PATH NEEDS WORK TO ALLOW CUSTOM FOLDERS
-
-
 import argparse
 import os
 import urllib.request as urlreq

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
-# DOWNLOAD PATH NEEDS WORK TO ALLOW CUSTOM FOLDERS
-
-
 import argparse
 import os
 import urllib.request as urlreq

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -139,7 +139,7 @@ for magazine_key, magazine in filtered_magazines.items():
         raise Exception('Could not find latest ' + magazine.name + ' issue number')
     else:
         if not args.quiet:
-            print('\nLatest {} issue is N°{:02d}'.format(magazine.name, int(last_issue)) )
+            print('Latest {} issue is N°{:02d}'.format(magazine.name, int(last_issue)) )
 
     start_issue = int(last_issue)-3 if args.all else int(last_issue)
 
@@ -164,10 +164,8 @@ for magazine_key, magazine in filtered_magazines.items():
             except:
                 if not args.quiet:
                     print(
-                        log.ERROR
-                        + ' Couldn\'t download the magazine'
-                        + colors.FADE
-                        + '\nYou may need to wait for the free download'
+                        colors.FADE
+                        + 'You may need to wait for the free download.\n'
                         + colors.ENDC
                     )
                 download_error = True
@@ -178,9 +176,8 @@ for magazine_key, magazine in filtered_magazines.items():
                         + '{} N°{:02d} downloaded!'.format(magazine.name, issue)
                         + colors.ENDC
                     )
-            # finally:
-            #     if not args.quiet: print()  # Breaks formatting
-
+        
+        
     if args.books:
 
         books = {}
@@ -208,7 +205,7 @@ for magazine_key, magazine in filtered_magazines.items():
                     
                     if not os.path.exists(book_path):
                         if not args.quiet:
-                            print('\nLatest {} book is \'{}\''.format(magazine.name, book_name))
+                            print('Latest {} book is \'{}\''.format(magazine.name, book_name))
                         try:
                             r = requests.get(base_url + book_href + '/pdf/download')
                             data = r.text
@@ -222,10 +219,8 @@ for magazine_key, magazine in filtered_magazines.items():
                         except:
                             if not args.quiet:
                                 print(
-                                    log.ERROR
-                                    + ' Couldn\'t download the book'
-                                    + colors.FADE
-                                    + '.\nYou may need to wait for the free download'
+                                    colors.FADE
+                                    + 'You may need to wait for the free download.\n'
                                     + colors.ENDC
                                 )
                             download_error = True
@@ -237,13 +232,17 @@ for magazine_key, magazine in filtered_magazines.items():
                                     + colors.ENDC
                                 )
 
+
 if not args.quiet:
     if not download and not download_error:
-        print(colors.OK + 'You are up to date.' + colors.ENDC)
-
+        print(
+            colors.OK 
+            + 'You are up to date.\n' 
+            + colors.ENDC
+        )
     print(
         colors.OK
-        + '\nYour favorite magazines are waiting for you in file://'
+        + 'Your favorite magazines are waiting for you in file://'
         + os.path.join(output_base_path)
         + colors.ENDC
     )

--- a/scripts/rpipress-downloader
+++ b/scripts/rpipress-downloader
@@ -176,7 +176,14 @@ for magazine_key, magazine in filtered_magazines.items():
                         + colors.ENDC
                     )
         
-        
+    if not args.quiet:
+        if not download_magazine and not download_magazine_error:
+            print(
+                colors.OK 
+                + 'You are up to date.' 
+                + colors.ENDC
+            )
+            
     if args.books:
         books = {}
 
@@ -212,7 +219,6 @@ for magazine_key, magazine in filtered_magazines.items():
                             url = base_url + tag['href']
                             show_progress = progress_bar if not args.quiet else None
                             urlreq.urlretrieve(url, book_path, show_progress)
-                            download_magazine = True
 
                         except:
                             if not args.quiet:
@@ -221,7 +227,6 @@ for magazine_key, magazine in filtered_magazines.items():
                                     + 'You may need to wait for the free download.'
                                     + colors.ENDC
                                 )
-                            download_magazine_error = True
                         else:
                             if not args.quiet:
                                 print(
@@ -229,14 +234,6 @@ for magazine_key, magazine in filtered_magazines.items():
                                     +'{} book \'{}\' downloaded!'.format(magazine.name, book_name)
                                     + colors.ENDC
                                 )
-
-    if not args.quiet:
-        if not download_magazine and not download_magazine_error:
-            print(
-                colors.OK 
-                + 'You are up to date.' 
-                + colors.ENDC
-            )
 
 if not args.quiet:
     print(


### PR DESCRIPTION
Improved the readability of terminal output

`-p` now allows for alternate folder names
_(Before it was inserting `rpipress` into the -p)_


Hope this is all good, not tested via snap, might be borked (Line 113 & 114). Wrote it while still under the influence of anaesthetics.

![image](https://github.com/artivis/rpipress-downloader/assets/16861223/734dbc79-6d1e-46bc-96b0-62027c223e9b)